### PR TITLE
Update Jakarta README.md - Remove the check dependency on ping.

### DIFF
--- a/scenarios/jakarta/README.md
+++ b/scenarios/jakarta/README.md
@@ -2,21 +2,21 @@
 
 ## Description
 
-Can't <kbd>ping google.com</kbd>. It returns <kbd>ping: google.com: Name or service not known</kbd>. Expected is being able to resolve the hostname. (Note: currently the VMs can't ping outside so there's no automated check for the solution).
+Can't <kbd>ping google.com</kbd>. It returns <kbd>ping: google.com: Name or service not known</kbd>. Expected is being able to resolve the hostname. (Note: currently, the VMs can't ping outside).
 
 ## Test
 
-<kbd>ping -c 1 -q google.com |grep packets| cut -d',' -f2,3</kbd> should return <kbd>1 received, 0% packet loss</kbd><br>
 <kbd>ping google.com</kbd> should return something like <kbd>PING google.com (172.217.2.46) 56(84) bytes of data.</kbd>
 
 <b>check.sh</b>
 
-```
+```bash
 #!/usr/bin/bash
-res=$(curl -Is -m 2 google.com |head -1)
-res=$(echo $res|tr -d '\r')
 
-if [[ "$res" = "HTTP/1.1 301 Moved Permanently" ]]
+# Use getent to query the system's name resolution for google.com
+res=$(getent hosts google.com)
+
+if [[ -n "$res" ]]
 then
   echo -n "OK"
 else


### PR DESCRIPTION
Instead of using `ping` to test the system's standard DNS resolution process, I propose using `getent` instead since it doesn't require communication with the outside world.

The `getent` command with the `hosts` argument utilises the system's libc resolver to perform name lookups based on the configuration specified in `/etc/nsswitch.conf`. This approach ensures the testing of the system's actual name resolution pathway, as would be used by most applications and tools on the system that rely on DNS resolution.

I tested the script in the Jakarta VM and it worked as expected.